### PR TITLE
change the result parser to work in async mode

### DIFF
--- a/razi/rdkit_postgresql/types.py
+++ b/razi/rdkit_postgresql/types.py
@@ -40,6 +40,8 @@ class Mol(UserDefinedType):
                 return value
             elif isinstance(value, memoryview):
                 return Chem.Mol(bytes(value))
+            elif isinstance(value, str):
+                value = memoryview(Chem.MolFromSmiles(value).ToBinary())
             else:
                 raise RuntimeError(
                     "Unexpected row value type for a Mol instance")
@@ -96,6 +98,8 @@ class Bfp(UserDefinedType):
                 return value
             elif isinstance(value, memoryview):
                 return DataStructs.CreateFromBinaryText(bytes(value))
+            elif isinstance(value, bytes):
+                return DataStructs.CreateFromBinaryText(value)
             else:
                 raise RuntimeError(
                     "Unexpected row value type for a Bfp instance")


### PR DESCRIPTION
when u use the sqlalchemy in the async mode. Select result of bfp or mol column is bytes , not the memoryview. So the razi will raise a runtime error, it can't work .
I add the type check to generate right behavior in the async mode