### PR TITLE
fix issue with dialect difference in sqlalchemy>=2.0.0

### DIFF
--- a/razi/rdkit_postgresql/comparator.py
+++ b/razi/rdkit_postgresql/comparator.py
@@ -33,7 +33,7 @@ class BfpComparator(UserDefinedType.Comparator):
 
     def tanimoto_sml(self, other):
         return self.operate(
-            operators.custom_op('%%'), other, result_type=sqltypes.Boolean
+            operators.custom_op('%'), other, result_type=sqltypes.Boolean
             )
 
     def dice_sml(self, other):
@@ -46,7 +46,7 @@ class SfpComparator(UserDefinedType.Comparator):
 
     def tanimoto_sml(self, other):
         return self.operate(
-            operators.custom_op('%%'), other, result_type=sqltypes.Boolean
+            operators.custom_op('%'), other, result_type=sqltypes.Boolean
             )
 
     def dice_sml(self, other):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(name='razi',
-    version='0.0.0',
+    version='0.1.0',
     description='Using SQLAlchemy with chemical databases',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -25,7 +25,8 @@ setuptools.setup(name='razi',
         'tests', 'tests.*',
     ]),
     install_requires=[
-        'SQLAlchemy>=0.7.0',
+        'SQLAlchemy>=2.0.0',
+        'rdkit>=2022.9.4'
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This adjusts the operator for new SQLAlchemy dialect introduced in SQLAlchemy 2.0.0. Additionally I've updated the version of this library (as those are breaking changes for anyone using SQLAlchemy<2.0.0) and I've adjusted requirements.